### PR TITLE
Cookie Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ __or__
 
 Use my container and supply your own `.env` file
 
-`docker run -d --env-file .env -p 3000:3000 quay.io/djsd123/auth0-golang-kube-app`
+`docker container run --rm -it --env-file < .env > -p 3000:3000 quay.io/mojanalytics/auth0-golang-kube-app`
 
 
 __Without Docker__
@@ -56,3 +56,15 @@ __Without Docker__
 * Run `go run main.go server.go`
 
 * Browse to [http://localhost:3000](http://localhost:3000)
+
+#### Logout
+
+Remember to __Logout__ to end your session once you have finished.
+
+#### Troubleshooting 
+
+Clearing __cookies__ tends to resolve any unexpected behaviour.  Particularly  __cookies__ with __localhost__ in the name
+
+
+Try accessing the app in another browser
+

--- a/app/app.go
+++ b/app/app.go
@@ -2,16 +2,18 @@ package app
 
 import (
 	"encoding/gob"
-
 	"github.com/gorilla/sessions"
+	"os"
+	"math"
 )
 
 var (
-	Store *sessions.CookieStore
+	Store *sessions.FilesystemStore
 )
 
 func Init() error {
-	Store = sessions.NewCookieStore([]byte("something-very-secret"))
+	Store = sessions.NewFilesystemStore(os.TempDir(), []byte("something-very-secret"))
+	Store.MaxLength(math.MaxInt64)
 	gob.Register(map[string]interface{}{})
 	return nil
 }

--- a/exec.ps1
+++ b/exec.ps1
@@ -1,2 +1,2 @@
-docker build --no-cache -t auth0-golang-kube-app .
-docker run -it --env-file .env -p 3000:3000 auth0-golang-kube-app
+docker image build --no-cache -t auth0-golang-kube-app .
+docker container run -it --rm --env-file env.dev -p 3000:3000 auth0-golang-kube-app

--- a/exec.sh
+++ b/exec.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-docker build --no-cache -t auth0-golang-kube-app .
-docker run -it --env-file .env -p 3000:3000 auth0-golang-kube-app
+docker image build --no-cache -t auth0-golang-kube-app .
+docker container run -it --rm --env-file ~/Documents/env.dev -p 3000:3000 auth0-golang-kube-app

--- a/routes/login/login.go
+++ b/routes/login/login.go
@@ -18,7 +18,7 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 		ClientID:     os.Getenv("AUTH0_CLIENT_ID"),
 		ClientSecret: os.Getenv("AUTH0_CLIENT_SECRET"),
 		RedirectURL:  os.Getenv("AUTH0_CALLBACK_URL"),
-		Scopes:       []string{"openid", "offline_access"},
+		Scopes:       []string{"openid", "profile", "offline_access"},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  "https://" + domain + "/authorize",
 			TokenURL: "https://" + domain + "/oauth/token",


### PR DESCRIPTION
Re-added profile scope

Replaced cookie store with filesystem store to adress "cookie too large"
error.

Reviewed exec script and README

## Test

1. You'll need an env file with the auth0 client config.  I can provide this.  Pass the provided file to the command below as the argument to `--env-file`

`docker container run --rm -it --env-file < .env > -p 3000:3000 quay.io/mojanalytics/auth0-golang-kube-app`

2. Run the above command then browse to [auth0-golang-kube-app](localhost:3000) and sign in

You should be presented with your id and refresh token.

3. Do not forget to __Logout__.  While not essential, this action will clear up any stored data i.e. `cookies`
